### PR TITLE
add title and description in nuxt.config for SEO purposes

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,14 +4,15 @@ export default {
    ** Headers of the page
    */
   head: {
-    title: process.env.npm_package_name || '',
+    title: 'Eugene Code Camp',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       {
         hid: 'description',
         name: 'description',
-        content: process.env.npm_package_description || ''
+        content:
+          'A local meetup for learning how to code, exploring tools, and getting support in the tech industry.'
       }
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]


### PR DESCRIPTION
I put the generic title/description on the nuxt.config file. Once we have pages, we can put the meta data in the head method on the individual pages. I don't think there's ever a reason to use the package title/description, but let me know if I should update those, too.

resolves https://github.com/EugeneCodeCamp/EugeneCodeCamp.github.io/issues/27